### PR TITLE
Load before hyperverse and create automatic releases

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,53 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+on:
+  push:
+    tags:
+    - '*'
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Get version information
+      id: version
+      uses: ncipollo/semantic-version-action@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Cache Maven packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Build with Maven
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: mvn -B package --file pom.xml
+    - run: mkdir staging && cp target/*.jar staging
+    - name: Generate release diff
+      env:
+        BEGIN_COMMIT: ${{ steps.version.outputs.previous_tag }}
+        END_COMMIT: ${{ steps.version.outputs.tag }}
+      run: git fetch --tags --force && git log --pretty=format:"* %s (%h)" ${BEGIN_COMMIT}..${END_COMMIT} > release_notes.md
+    - name: Create release
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: staging/*
+        allowUpdates: true
+        bodyFile: "release_notes.md"
+        draft: false
+        prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,11 @@ jobs:
     - name: Set up JDK 8
       uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 11
+        java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
+        architecture: x86 # (x64 or x86) - defaults to x64
+    - run: wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+    - run: java -jar BuildTools.jar --rev 1.16.4
     - name: Cache Maven packages
       uses: actions/cache@v1
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Get version information
       id: version
       uses: ncipollo/semantic-version-action@v1
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
         java-version: 11

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![Java CI with Maven](https://github.com/Kas-tle/CustomDimensions/workflows/Java%20CI%20with%20Maven/badge.svg)
 # CustomDimensions
 Custom dimension support for 1.16.4 Bukkit/Spigot/Paper servers
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.TBMCPlugins</groupId>
     <artifactId>CustomDimensions</artifactId>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.TBMCPlugins</groupId>
     <artifactId>CustomDimensions</artifactId>
-    <version>1.4</version>
+    <version>1.5.0</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,3 +4,4 @@ version: '1.4'
 api-version: '1.16'
 loadbefore:
   - Multiverse-Core
+  - Hyperverse


### PR DESCRIPTION
This PR forces load before Hyperverse loads, another multiworld plugin. Beyond that I believe it should work fine as it seems to detect worlds in the same manner as Multiverse did. I also added an action to publish builds automatically on any push with a semantic-format version tag (e.g. 1.5.1).