### PR TITLE
Update to 1.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,47 +6,34 @@
 
     <groupId>com.github.TBMCPlugins</groupId>
     <artifactId>CustomDimensions</artifactId>
-    <version>1.6.0</version>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <!-- Make sure we're not using Java 9+ APIs -->
-                    <release>8</release>
-                    <source>14</source>
-                    <target>14</target>
-                    <compilerArgs>
-                        <arg>-Xplugin:jabel</arg>
-                    </compilerArgs>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
-                <configuration>
-                    <relocations>
-                        <relocation>
-                            <pattern>org.bstats</pattern>
-                            <shadedPattern>buttondevteam.customdimensions.bstats</shadedPattern>
-                        </relocation>
-                    </relocations>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    <version>1.6.1</version>
+	<build>
+		<defaultGoal>clean package install</defaultGoal>
+		<finalName>${project.name}-${project.version}</finalName>
+		<sourceDirectory>${project.basedir}/src</sourceDirectory>
+		<resources>
+			<resource>
+				<targetPath>.</targetPath>
+				<filtering>true</filtering>
+				<directory>${project.basedir}/src/</directory>
+				<includes>
+					<include>plugin.yml</include>
+				</includes>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>8</source>
+					<target>8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 
     <repositories>
         <repository>
@@ -60,48 +47,18 @@
     </repositories>
 
     <dependencies>
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.bsideup.jabel</groupId>
-            <artifactId>jabel-javac-plugin</artifactId>
-            <version>0.3.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.bstats</groupId>
-            <artifactId>bstats-bukkit</artifactId>
-            <version>2.2.1</version>
-            <scope>compile</scope>
-        </dependency>
+    <dependency>
+           <groupId>org.spigotmc</groupId>
+           <artifactId>spigot-api</artifactId>
+           <version>1.17-R0.1-SNAPSHOT</version>
+           <scope>provided</scope>
+    </dependency>
+    	<dependency>
+			<groupId>org.spigotmc</groupId>
+			<artifactId>spigot</artifactId>
+			<version>1.17</version>
+			<scope>system</scope>
+			<systemPath>${project.basedir}/utils/spigot-1.17.jar</systemPath>
+		</dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>intellij-idea-only</id>
-            <activation>
-                <property>
-                    <name>idea.maven.embedder.version</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <release>14</release>
-                            <compilerArgs>
-                                <arg>--enable-preview</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/src/main/java/buttondevteam/customdimensions/CustomDimensions.java
+++ b/src/main/java/buttondevteam/customdimensions/CustomDimensions.java
@@ -4,13 +4,48 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Callables;
+import com.mojang.serialization.DynamicOps;
 import com.mojang.serialization.Lifecycle;
-import net.minecraft.server.v1_16_R3.*;
-import org.bstats.bukkit.Metrics;
-import org.bstats.charts.SimplePie;
+
+import net.minecraft.core.IRegistry;
+import net.minecraft.core.IRegistryCustom;
+import net.minecraft.core.RegistryMaterials;
+import net.minecraft.nbt.DynamicOpsNBT;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.resources.MinecraftKey;
+import net.minecraft.resources.RegistryReadOps;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.*;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.level.WorldServer;
+import net.minecraft.server.level.progress.WorldLoadListener;
+import net.minecraft.util.datafix.DataConverterRegistry;
+import net.minecraft.world.EnumDifficulty;
+import net.minecraft.world.entity.ai.village.VillageSiege;
+import net.minecraft.world.entity.npc.MobSpawnerCat;
+import net.minecraft.world.entity.npc.MobSpawnerTrader;
+import net.minecraft.world.level.EnumGamemode;
+import net.minecraft.world.level.GameRules;
+import net.minecraft.world.level.MobSpawner;
+import net.minecraft.world.level.World;
+import net.minecraft.world.level.WorldSettings;
+import net.minecraft.world.level.biome.BiomeManager;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.dimension.DimensionManager;
+import net.minecraft.world.level.dimension.WorldDimension;
+import net.minecraft.world.level.levelgen.GeneratorSettings;
+import net.minecraft.world.level.levelgen.MobSpawnerPatrol;
+import net.minecraft.world.level.levelgen.MobSpawnerPhantom;
+import net.minecraft.world.level.storage.Convertable;
+import net.minecraft.world.level.storage.Convertable.ConversionSession;
+import net.minecraft.world.level.storage.SaveData;
+import net.minecraft.world.level.storage.WorldDataServer;
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType;
+import net.minecraft.server.packs.resources.IResourceManager;
+
 import org.bukkit.Bukkit;
 import org.bukkit.WorldType;
-import org.bukkit.craftbukkit.v1_16_R3.CraftServer;
+import org.bukkit.craftbukkit.v1_17_R1.CraftServer;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.WorldInitEvent;
 import org.bukkit.event.world.WorldLoadEvent;
@@ -18,14 +53,14 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.*;
+import java.util.Map.Entry;
 
 public class CustomDimensions extends JavaPlugin implements Listener {
-	private Metrics metrics;
 
 	@Override
 	public void onEnable() {
-		metrics = new Metrics(this, 10545);
 		getLogger().info("Loading custom dimensions...");
 		try {
 			load();
@@ -36,24 +71,28 @@ public class CustomDimensions extends JavaPlugin implements Listener {
 	}
 
 	private void load() throws Exception {
-		var console = ((CraftServer) Bukkit.getServer()).getServer();
-		var field = console.getClass().getSuperclass().getDeclaredField("saveData");
+		DedicatedServer console = ((CraftServer) Bukkit.getServer()).getServer();
+		System.out.println("******************************************");
+		for (Field fie : console.getClass().getSuperclass().getDeclaredFields()) {
+			System.out.println(fie.getName());
+		}
+		Field field = console.getClass().getSuperclass().getDeclaredField("saveData");
 		field.setAccessible(true);
-		var saveData = (SaveData) field.get(console);
+		SaveData saveData = (SaveData) field.get(console);
 		GeneratorSettings mainGenSettings = saveData.getGeneratorSettings();
 		RegistryMaterials<WorldDimension> dimensionRegistry = mainGenSettings.d();
 
-		var mainWorld = Bukkit.getWorlds().get(0);
+		org.bukkit.World mainWorld = Bukkit.getWorlds().get(0);
 
-		var convertable = Convertable.a(Bukkit.getWorldContainer().toPath());
+		Convertable convertable = Convertable.a(Bukkit.getWorldContainer().toPath());
 
 		if (!getConfig().contains("ignored")) {
 			getConfig().set("ignored", Lists.newArrayList("single_biome"));
 			saveConfig();
 		}
-		var ignored = getConfig().getStringList("ignored");
+		List<String> ignored = getConfig().getStringList("ignored");
 		int allCount = -3, loadedCount = 0, ignoredCount = 0; //-3: overworld, nether, end
-		for (var dimEntry : dimensionRegistry.d()) {
+		for (Entry<ResourceKey<WorldDimension>, WorldDimension> dimEntry : dimensionRegistry.d()) {
 			allCount++;
 			if (ignored.contains(dimEntry.getKey().a().getKey())) {
 				getLogger().info(dimEntry.getKey() + " is on the ignore list");
@@ -68,18 +107,17 @@ public class CustomDimensions extends JavaPlugin implements Listener {
 				e.printStackTrace();
 			}
 		}
-		metrics.addCustomChart(new SimplePie("all_custom_dimensions", Callables.returning(allCount + "")));
-		metrics.addCustomChart(new SimplePie("loaded_custom_dimensions", Callables.returning(loadedCount + "")));
-		metrics.addCustomChart(new SimplePie("ignored_custom_dimensions", Callables.returning(ignoredCount + "")));
+
 	}
 
 	private boolean loadDimension(ResourceKey<WorldDimension> dimKey, WorldDimension dimension,
 	                              Convertable convertable, DedicatedServer console, org.bukkit.World mainWorld) throws IOException {
-		if (dimKey == WorldDimension.OVERWORLD //The default dimensions are already loaded
-				|| dimKey == WorldDimension.THE_NETHER
-				|| dimKey == WorldDimension.THE_END)
+		if (dimKey == WorldDimension.a //The default dimensions are already loaded
+				|| dimKey == WorldDimension.b
+				|| dimKey == WorldDimension.c
+				|| dimKey == WorldDimension.d)
 			return false;
-		ResourceKey<World> worldKey = ResourceKey.a(IRegistry.L, dimKey.a());
+		ResourceKey<World> worldKey = ResourceKey.a(IRegistry.Q, dimKey.a());
 		DimensionManager dimensionmanager = dimension.b();
 		ChunkGenerator chunkgenerator = dimension.c();
 		String name = getConfig().getString("worldNames." + dimKey.a());
@@ -90,16 +128,16 @@ public class CustomDimensions extends JavaPlugin implements Listener {
 			return false;
 		}
 		getLogger().info("Loading " + name);
-		var session = convertable.new ConversionSession(name, dimKey) { //The original session isn't prepared for custom dimensions
+		ConversionSession session = convertable.new ConversionSession(name, dimKey) { //The original session isn't prepared for custom dimensions
 			@Override
 			public File a(ResourceKey<World> resourcekey) {
-				return new File(this.folder.toFile(), "custom");
+				return new File(this.c.toFile(), "custom");
 			}
 		};
 		MinecraftServer.convertWorld(session);
 
 		//Load world settings or create default values
-		RegistryReadOps<NBTBase> registryreadops = RegistryReadOps.a(DynamicOpsNBT.a, console.dataPackResources.h(), console.customRegistry);
+		RegistryReadOps<NBTBase> registryreadops = RegistryReadOps.a((DynamicOps<NBTBase>) DynamicOpsNBT.a, console.aC.i(), console.getCustomRegistry());
 		WorldDataServer worlddata = (WorldDataServer) session.a(registryreadops, console.datapackconfiguration);
 		if (worlddata == null) {
 			Properties properties = new Properties();
@@ -110,35 +148,36 @@ public class CustomDimensions extends JavaPlugin implements Listener {
 			WorldSettings worldSettings = new WorldSettings(name,
 					EnumGamemode.getById(Bukkit.getDefaultGameMode().getValue()),
 					false, //Hardcore
-					EnumDifficulty.EASY, false, new GameRules(), console.datapackconfiguration);
+					EnumDifficulty.a, false, new GameRules(), console.datapackconfiguration);
 			worlddata = new WorldDataServer(worldSettings, dimGenSettings, Lifecycle.stable());
 		}
 
 		worlddata.checkName(name);
 		worlddata.a(console.getServerModName(), console.getModded().isPresent());
 		if (console.options.has("forceUpgrade")) {
-			net.minecraft.server.v1_16_R3.Main.convertWorld(session, DataConverterRegistry.a(),
+			net.minecraft.server.Main.convertWorld(session, DataConverterRegistry.a(),
 					console.options.has("eraseCache"), () -> true,
 					worlddata.getGeneratorSettings().d().d().stream()
-							.map((entry2) -> ResourceKey.a(IRegistry.K, entry2.getKey().a()))
+							.map((entry2) -> ResourceKey.a(IRegistry.P, entry2.getKey().a()))
 							.collect(ImmutableSet.toImmutableSet()));
 		}
 
 		List<MobSpawner> spawners = ImmutableList.of(new MobSpawnerPhantom(), new MobSpawnerPatrol(), new MobSpawnerCat(), new VillageSiege(), new MobSpawnerTrader(worlddata));
 
-		ResourceKey<DimensionManager> dimManResKey = ResourceKey.a(IRegistry.K, dimKey.a());
-		var dimRegistry = ((RegistryMaterials<DimensionManager>) console.customRegistry.a());
+		
+		ResourceKey<DimensionManager> dimManResKey = ResourceKey.a(IRegistry.P, dimKey.a());
+
+		RegistryMaterials<DimensionManager> dimRegistry = new RegistryMaterials<DimensionManager>(null, null); //((RegistryMaterials<DimensionManager>));
 		{
-			var key = dimRegistry.getKey(dimensionmanager);
+			MinecraftKey key = dimRegistry.getKey(dimensionmanager);
 			if (key == null) { //The loaded manager is different - different dimension type
 				//Replace existing dimension manager, correctly setting the ID up (which is -1 for default worlds...)
 				dimRegistry.a(OptionalInt.empty(), dimManResKey, dimensionmanager, Lifecycle.stable());
 			}
 		}
 
-		var worldloadlistener = console.worldLoadListenerFactory.create(11);
-
-		WorldServer worldserver = new WorldServer(console, console.executorService, session,
+		WorldLoadListener worldloadlistener = console.L.create(11);
+		WorldServer worldserver = new WorldServer(console, console.aA, session,
 				worlddata, worldKey, dimensionmanager, worldloadlistener, chunkgenerator,
 				false, //isDebugWorld
 				BiomeManager.a(worlddata.getGeneratorSettings().getSeed()), //Biome seed
@@ -152,9 +191,9 @@ public class CustomDimensions extends JavaPlugin implements Listener {
 		} else {
 			console.initWorld(worldserver, worlddata, worlddata, worlddata.getGeneratorSettings());
 			worldserver.setSpawnFlags(true, true);
-			console.worldServer.put(worldserver.getDimensionKey(), worldserver);
+			console.R.put(worldserver.getDimensionKey(), worldserver);
 			Bukkit.getPluginManager().callEvent(new WorldInitEvent(worldserver.getWorld()));
-			console.loadSpawn(worldserver.getChunkProvider().playerChunkMap.worldLoadListener, worldserver);
+			console.loadSpawn(worldserver.getChunkProvider().a.z, worldserver);
 			Bukkit.getPluginManager().callEvent(new WorldLoadEvent(worldserver.getWorld()));
 			return true;
 		}

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,0 +1,7 @@
+name: CustomDimensions
+main: buttondevteam.customdimensions.CustomDimensions
+api-version: 1.14
+version: 1.17
+loadbefore:
+  - Multiverse-Core
+  - Hyperverse


### PR DESCRIPTION
I spent a few hours attempting to update the plugin to work on 1.17.

From my trials it works for my purposes and was able to load custom dimensions but there are still a few errors. 

One thing I couldn't figure out was how to convert this line

`var dimRegistry = ((RegistryMaterials<DimensionManager>) console.customRegistry.a());`

This is what i had in there just to remove the error, merely just a placeholder

`RegistryMaterials<DimensionManager> dimRegistry = new RegistryMaterials<DimensionManager>(null, null);`

Uh I realize I changed the pom.xml and added another file, really that's just to show what i was working with and what was done on my end to have it functioning. 